### PR TITLE
start-env: specify registry path in docker images URLs

### DIFF
--- a/project-pink-einstein/rng/build.sh
+++ b/project-pink-einstein/rng/build.sh
@@ -2,7 +2,7 @@
 
 set -eux -o pipefail
 
-DOCKER_IMG="golang:1.16.2-alpine@sha256:4891e17c9d2de88ebd1d9421919539226a76773d6ad1b4ac7376b286039c9be2"
+DOCKER_IMG="docker.io/golang:1.16.2-alpine@sha256:4891e17c9d2de88ebd1d9421919539226a76773d6ad1b4ac7376b286039c9be2"
 SCRIPT_DIR="$(cd "$(dirname "$0")" ; pwd -P)"
 
 if [ $# -ne 1 ]; then

--- a/project-pink-einstein/unixtime/Makefile
+++ b/project-pink-einstein/unixtime/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMG=ownyourbits/mmake@sha256:c43710f2234e13666b8672a3b6e4f1706335a116ad5f9b8dc77fcf234aa08166
+DOCKER_IMG=docker.io/ownyourbits/mmake@sha256:c43710f2234e13666b8672a3b6e4f1706335a116ad5f9b8dc77fcf234aa08166
 default: dist/unixtime
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/start-env.sh
+++ b/start-env.sh
@@ -10,7 +10,7 @@ if ! command -v; then
 	exit 1
 fi
 
-docker run -d --rm -p 127.0.0.1:$REGISTRY_PORT:5000 --name docker-registry registry:2
+docker run -d --rm -p 127.0.0.1:$REGISTRY_PORT:5000 --name docker-registry docker.io/registry:2
 echo "Started docker registry container on port $REGISTRY_PORT"
 
 
@@ -20,7 +20,7 @@ docker run \
 	-p 127.0.0.1:$PSQL_PORT:5432 \
 	-e POSTGRES_HOST_AUTH_METHOD=trust \
 	-e POSTGRES_DB=baur \
-	postgres:latest
+	docker.io/postgres:latest
 
 echo "Started docker PostgreSQL container on port $PSQL_PORT"
 echo "Run 'baur init db' to initialize the database for baur"


### PR DESCRIPTION
Podman (podman-docker) does not assume that docker.io is the default-registry. To make the scripts compatible with podman, specify docker.io as registry explicitly when referencing docker images.